### PR TITLE
feat(color): update more global colors

### DIFF
--- a/src/account/__snapshots__/AccountKeyEducation.test.tsx.snap
+++ b/src/account/__snapshots__/AccountKeyEducation.test.tsx.snap
@@ -161,6 +161,7 @@ exports[`AccountKeyEducation renders correctly 1`] = `
               <Text
                 style={
                   {
+                    "color": "#FFFFFF",
                     "fontFamily": "Inter-Bold",
                     "fontSize": 20,
                     "lineHeight": 28,
@@ -174,6 +175,7 @@ exports[`AccountKeyEducation renders correctly 1`] = `
               <Text
                 style={
                   {
+                    "color": "#FFFFFF",
                     "fontFamily": "Inter-Regular",
                     "fontSize": 16,
                     "lineHeight": 24,
@@ -231,6 +233,7 @@ exports[`AccountKeyEducation renders correctly 1`] = `
               <Text
                 style={
                   {
+                    "color": "#FFFFFF",
                     "fontFamily": "Inter-Bold",
                     "fontSize": 20,
                     "lineHeight": 28,
@@ -244,6 +247,7 @@ exports[`AccountKeyEducation renders correctly 1`] = `
               <Text
                 style={
                   {
+                    "color": "#FFFFFF",
                     "fontFamily": "Inter-Regular",
                     "fontSize": 16,
                     "lineHeight": 24,
@@ -301,6 +305,7 @@ exports[`AccountKeyEducation renders correctly 1`] = `
               <Text
                 style={
                   {
+                    "color": "#FFFFFF",
                     "fontFamily": "Inter-Bold",
                     "fontSize": 20,
                     "lineHeight": 28,
@@ -314,6 +319,7 @@ exports[`AccountKeyEducation renders correctly 1`] = `
               <Text
                 style={
                   {
+                    "color": "#FFFFFF",
                     "fontFamily": "Inter-Regular",
                     "fontSize": 16,
                     "lineHeight": 24,
@@ -371,6 +377,7 @@ exports[`AccountKeyEducation renders correctly 1`] = `
               <Text
                 style={
                   {
+                    "color": "#FFFFFF",
                     "fontFamily": "Inter-Bold",
                     "fontSize": 20,
                     "lineHeight": 28,
@@ -384,6 +391,7 @@ exports[`AccountKeyEducation renders correctly 1`] = `
               <Text
                 style={
                   {
+                    "color": "#FFFFFF",
                     "fontFamily": "Inter-Regular",
                     "fontSize": 16,
                     "lineHeight": 24,

--- a/src/account/__snapshots__/Education.test.tsx.snap
+++ b/src/account/__snapshots__/Education.test.tsx.snap
@@ -147,6 +147,7 @@ exports[`Education renders correctly 1`] = `
               <Text
                 style={
                   {
+                    "color": "#FFFFFF",
                     "fontFamily": "Inter-Bold",
                     "fontSize": 20,
                     "lineHeight": 28,
@@ -160,6 +161,7 @@ exports[`Education renders correctly 1`] = `
               <Text
                 style={
                   {
+                    "color": "#FFFFFF",
                     "fontFamily": "Inter-Regular",
                     "fontSize": 16,
                     "lineHeight": 24,

--- a/src/account/__snapshots__/GoldEducation.test.tsx.snap
+++ b/src/account/__snapshots__/GoldEducation.test.tsx.snap
@@ -161,6 +161,7 @@ exports[`renders correctly 1`] = `
               <Text
                 style={
                   {
+                    "color": "#FFFFFF",
                     "fontFamily": "Inter-Bold",
                     "fontSize": 20,
                     "lineHeight": 28,
@@ -174,6 +175,7 @@ exports[`renders correctly 1`] = `
               <Text
                 style={
                   {
+                    "color": "#FFFFFF",
                     "fontFamily": "Inter-Regular",
                     "fontSize": 16,
                     "lineHeight": 24,
@@ -231,6 +233,7 @@ exports[`renders correctly 1`] = `
               <Text
                 style={
                   {
+                    "color": "#FFFFFF",
                     "fontFamily": "Inter-Bold",
                     "fontSize": 20,
                     "lineHeight": 28,
@@ -244,6 +247,7 @@ exports[`renders correctly 1`] = `
               <Text
                 style={
                   {
+                    "color": "#FFFFFF",
                     "fontFamily": "Inter-Regular",
                     "fontSize": 16,
                     "lineHeight": 24,
@@ -301,6 +305,7 @@ exports[`renders correctly 1`] = `
               <Text
                 style={
                   {
+                    "color": "#FFFFFF",
                     "fontFamily": "Inter-Bold",
                     "fontSize": 20,
                     "lineHeight": 28,
@@ -314,6 +319,7 @@ exports[`renders correctly 1`] = `
               <Text
                 style={
                   {
+                    "color": "#FFFFFF",
                     "fontFamily": "Inter-Regular",
                     "fontSize": 16,
                     "lineHeight": 24,
@@ -371,6 +377,7 @@ exports[`renders correctly 1`] = `
               <Text
                 style={
                   {
+                    "color": "#FFFFFF",
                     "fontFamily": "Inter-Bold",
                     "fontSize": 20,
                     "lineHeight": 28,
@@ -384,6 +391,7 @@ exports[`renders correctly 1`] = `
               <Text
                 style={
                   {
+                    "color": "#FFFFFF",
                     "fontFamily": "Inter-Regular",
                     "fontSize": 16,
                     "lineHeight": 24,

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -79,7 +79,7 @@ export class App extends React.Component<Props> {
                 appStartedMillis={this.props.appStartedMillis}
                 reactLoadTime={this.reactLoadTime}
               >
-                <StatusBar backgroundColor="transparent" barStyle="dark-content" />
+                <StatusBar backgroundColor="transparent" barStyle="light-content" />
                 <ErrorBoundary>
                   <GestureHandlerRootView style={{ flex: 1 }}>
                     <BottomSheetModalProvider>

--- a/src/app/__snapshots__/ErrorScreen.test.tsx.snap
+++ b/src/app/__snapshots__/ErrorScreen.test.tsx.snap
@@ -35,6 +35,7 @@ exports[`ErrorScreen with errorMessage renders correctly 1`] = `
     <Text
       style={
         {
+          "color": "#FFFFFF",
           "fontFamily": "Inter-Bold",
           "fontSize": 24,
           "lineHeight": 32,
@@ -46,6 +47,7 @@ exports[`ErrorScreen with errorMessage renders correctly 1`] = `
     <Text
       style={
         {
+          "color": "#FFFFFF",
           "fontFamily": "Inter-Bold",
           "fontSize": 20,
           "lineHeight": 28,
@@ -63,6 +65,7 @@ exports[`ErrorScreen with errorMessage renders correctly 1`] = `
         {
           "backgroundColor": "#363B63",
           "borderRadius": 25,
+          "color": "#FFFFFF",
           "fontFamily": "Inter-Regular",
           "fontSize": 12,
           "lineHeight": 24,
@@ -211,6 +214,7 @@ exports[`ErrorScreen without errorMessage renders correctly 1`] = `
     <Text
       style={
         {
+          "color": "#FFFFFF",
           "fontFamily": "Inter-Bold",
           "fontSize": 24,
           "lineHeight": 32,
@@ -222,6 +226,7 @@ exports[`ErrorScreen without errorMessage renders correctly 1`] = `
     <Text
       style={
         {
+          "color": "#FFFFFF",
           "fontFamily": "Inter-Bold",
           "fontSize": 20,
           "lineHeight": 28,
@@ -239,6 +244,7 @@ exports[`ErrorScreen without errorMessage renders correctly 1`] = `
         {
           "backgroundColor": "#363B63",
           "borderRadius": 25,
+          "color": "#FFFFFF",
           "fontFamily": "Inter-Regular",
           "fontSize": 12,
           "lineHeight": 24,

--- a/src/backup/__snapshots__/BackupComplete.test.tsx.snap
+++ b/src/backup/__snapshots__/BackupComplete.test.tsx.snap
@@ -42,6 +42,7 @@ exports[`BackupComplete renders correctly 1`] = `
     <Text
       style={
         {
+          "color": "#FFFFFF",
           "fontFamily": "Inter-Bold",
           "fontSize": 24,
           "lineHeight": 32,

--- a/src/backup/__snapshots__/BackupPhrase.test.tsx.snap
+++ b/src/backup/__snapshots__/BackupPhrase.test.tsx.snap
@@ -234,6 +234,7 @@ exports[`BackupPhrase renders correctly with backup completed 1`] = `
             <Text
               style={
                 {
+                  "color": "#FFFFFF",
                   "fontFamily": "Inter-Bold",
                   "fontSize": 20,
                   "lineHeight": 28,
@@ -267,6 +268,7 @@ exports[`BackupPhrase renders correctly with backup completed 1`] = `
       <Text
         style={
           {
+            "color": "#FFFFFF",
             "fontFamily": "Inter-Regular",
             "fontSize": 16,
             "lineHeight": 24,
@@ -515,6 +517,7 @@ exports[`BackupPhrase renders correctly with backup not completed 1`] = `
             <Text
               style={
                 {
+                  "color": "#FFFFFF",
                   "fontFamily": "Inter-Bold",
                   "fontSize": 20,
                   "lineHeight": 28,
@@ -548,6 +551,7 @@ exports[`BackupPhrase renders correctly with backup not completed 1`] = `
       <Text
         style={
           {
+            "color": "#FFFFFF",
             "fontFamily": "Inter-Regular",
             "fontSize": 16,
             "lineHeight": 24,
@@ -586,6 +590,7 @@ exports[`BackupPhrase renders correctly with backup not completed 1`] = `
       onPress={[Function]}
       style={
         {
+          "color": "#FFFFFF",
           "flex": 1,
           "fontFamily": "Inter-Regular",
           "fontSize": 16,
@@ -932,6 +937,7 @@ exports[`BackupPhrase still renders when mnemonic doesnt show up 1`] = `
             <Text
               style={
                 {
+                  "color": "#FFFFFF",
                   "fontFamily": "Inter-Bold",
                   "fontSize": 20,
                   "lineHeight": 28,
@@ -965,6 +971,7 @@ exports[`BackupPhrase still renders when mnemonic doesnt show up 1`] = `
       <Text
         style={
           {
+            "color": "#FFFFFF",
             "fontFamily": "Inter-Regular",
             "fontSize": 16,
             "lineHeight": 24,

--- a/src/backup/__snapshots__/BackupPhraseContainer.test.tsx.snap
+++ b/src/backup/__snapshots__/BackupPhraseContainer.test.tsx.snap
@@ -21,6 +21,7 @@ exports[`BackupPhraseContainer renders correctly for input backup phrase 1`] = `
       <Text
         style={
           {
+            "color": "#FFFFFF",
             "fontFamily": "Inter-Bold",
             "fontSize": 20,
             "lineHeight": 28,
@@ -51,6 +52,7 @@ exports[`BackupPhraseContainer renders correctly for input backup phrase 1`] = `
       style={
         [
           {
+            "color": "#FFFFFF",
             "fontFamily": "Inter-Regular",
             "fontSize": 16,
             "lineHeight": 24,
@@ -89,6 +91,7 @@ exports[`BackupPhraseContainer renders correctly for readonly backup 12-word phr
       <Text
         style={
           {
+            "color": "#FFFFFF",
             "fontFamily": "Inter-Bold",
             "fontSize": 20,
             "lineHeight": 28,
@@ -669,6 +672,7 @@ exports[`BackupPhraseContainer renders correctly for readonly backup 24-word phr
       <Text
         style={
           {
+            "color": "#FFFFFF",
             "fontFamily": "Inter-Bold",
             "fontSize": 20,
             "lineHeight": 28,
@@ -701,6 +705,7 @@ exports[`BackupPhraseContainer renders correctly for readonly backup 24-word phr
     <Text
       style={
         {
+          "color": "#FFFFFF",
           "fontFamily": "Inter-Regular",
           "fontSize": 22,
           "lineHeight": 32,

--- a/src/backup/__snapshots__/BackupQuiz.test.tsx.snap
+++ b/src/backup/__snapshots__/BackupQuiz.test.tsx.snap
@@ -875,6 +875,7 @@ exports[`BackupQuiz renders correctly 1`] = `
           <Text
             style={
               {
+                "color": "#FFFFFF",
                 "fontFamily": "Inter-Medium",
                 "fontSize": 16,
                 "lineHeight": 24,

--- a/src/components/BottomSheet.tsx
+++ b/src/components/BottomSheet.tsx
@@ -4,6 +4,7 @@ import { StyleSheet, Text, TextStyle, View, ViewStyle } from 'react-native'
 import { ScrollView } from 'react-native-gesture-handler'
 import BottomSheetBase from 'src/components/BottomSheetBase'
 import BottomSheetScrollView from 'src/components/BottomSheetScrollView'
+import Colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
 
@@ -55,7 +56,7 @@ const BottomSheet = ({
       )}
       <BottomSheetScrollView
         forwardedRef={scrollViewRef}
-        containerStyle={hasStickyHeader ? { paddingTop: 0 } : undefined}
+        containerStyle={[styles.container, hasStickyHeader ? { paddingTop: 0 } : undefined]}
         testId={testId}
       >
         {!stickyTitle && !!title && (
@@ -78,6 +79,9 @@ const styles = StyleSheet.create({
   description: {
     ...typeScale.bodySmall,
     marginBottom: Spacing.Smallest8,
+  },
+  container: {
+    backgroundColor: Colors.background,
   },
 })
 

--- a/src/components/BottomSheetBase.tsx
+++ b/src/components/BottomSheetBase.tsx
@@ -26,7 +26,7 @@ const BottomSheetBase = ({
   snapPoints,
   handleComponent,
   backgroundStyle,
-  handleIndicatorStyle = styles.handle,
+  handleIndicatorStyle = styles.handleIndicator,
 }: BottomSheetBaseProps) => {
   const reduceMotionEnabled = useReducedMotion()
 
@@ -64,6 +64,7 @@ const BottomSheetBase = ({
       enablePanDownToClose
       backdropComponent={renderBackdrop}
       handleComponent={handleComponent}
+      handleStyle={styles.handle}
       handleIndicatorStyle={handleIndicatorStyle}
       backgroundStyle={backgroundStyle}
       onAnimate={handleAnimate}
@@ -80,9 +81,14 @@ const BottomSheetBase = ({
 }
 
 const styles = StyleSheet.create({
-  handle: {
-    backgroundColor: Colors.blue200,
+  handleIndicator: {
+    backgroundColor: Colors.white,
     width: 40,
+  },
+  handle: {
+    backgroundColor: Colors.background,
+    borderTopLeftRadius: 16,
+    borderTopRightRadius: 16,
   },
 })
 

--- a/src/components/__snapshots__/Avatar.test.tsx.snap
+++ b/src/components/__snapshots__/Avatar.test.tsx.snap
@@ -45,6 +45,7 @@ exports[`Avatar renders correctly with address and name but no number 1`] = `
         style={
           [
             {
+              "color": "#FFFFFF",
               "fontFamily": "Inter-Medium",
               "fontSize": 16,
               "lineHeight": 24,
@@ -67,11 +68,13 @@ exports[`Avatar renders correctly with address and name but no number 1`] = `
     style={
       [
         {
+          "color": "#FFFFFF",
           "fontFamily": "Inter-Medium",
           "fontSize": 14,
           "lineHeight": 20,
         },
         {
+          "color": "#FFFFFF",
           "fontFamily": "Inter-Regular",
           "fontSize": 12,
           "letterSpacing": 0.12,
@@ -90,6 +93,7 @@ exports[`Avatar renders correctly with address and name but no number 1`] = `
     numberOfLines={1}
     style={
       {
+        "color": "#FFFFFF",
         "fontFamily": "Inter-Regular",
         "fontSize": 12,
         "letterSpacing": 0.12,
@@ -164,11 +168,13 @@ exports[`Avatar renders correctly with address but no name nor number 1`] = `
     style={
       [
         {
+          "color": "#FFFFFF",
           "fontFamily": "Inter-Medium",
           "fontSize": 14,
           "lineHeight": 20,
         },
         {
+          "color": "#FFFFFF",
           "fontFamily": "Inter-Regular",
           "fontSize": 12,
           "letterSpacing": 0.12,
@@ -244,11 +250,13 @@ exports[`Avatar renders correctly with just number 1`] = `
     style={
       [
         {
+          "color": "#FFFFFF",
           "fontFamily": "Inter-Medium",
           "fontSize": 14,
           "lineHeight": 20,
         },
         {
+          "color": "#FFFFFF",
           "fontFamily": "Inter-Regular",
           "fontSize": 12,
           "letterSpacing": 0.12,
@@ -273,6 +281,7 @@ exports[`Avatar renders correctly with just number 1`] = `
       style={
         {
           "alignItems": "center",
+          "color": "#FFFFFF",
           "fontFamily": "Inter-Regular",
           "fontSize": 14,
           "justifyContent": "center",
@@ -344,6 +353,7 @@ exports[`Avatar renders correctly with number and name 1`] = `
         style={
           [
             {
+              "color": "#FFFFFF",
               "fontFamily": "Inter-Medium",
               "fontSize": 16,
               "lineHeight": 24,
@@ -366,11 +376,13 @@ exports[`Avatar renders correctly with number and name 1`] = `
     style={
       [
         {
+          "color": "#FFFFFF",
           "fontFamily": "Inter-Medium",
           "fontSize": 14,
           "lineHeight": 20,
         },
         {
+          "color": "#FFFFFF",
           "fontFamily": "Inter-Regular",
           "fontSize": 12,
           "letterSpacing": 0.12,
@@ -395,6 +407,7 @@ exports[`Avatar renders correctly with number and name 1`] = `
       style={
         {
           "alignItems": "center",
+          "color": "#FFFFFF",
           "fontFamily": "Inter-Regular",
           "fontSize": 14,
           "justifyContent": "center",

--- a/src/components/__snapshots__/Dialog.test.tsx.snap
+++ b/src/components/__snapshots__/Dialog.test.tsx.snap
@@ -150,6 +150,7 @@ exports[`renders correctly 1`] = `
             <Text
               style={
                 {
+                  "color": "#FFFFFF",
                   "fontFamily": "Inter-Bold",
                   "fontSize": 20,
                   "lineHeight": 28,
@@ -163,6 +164,7 @@ exports[`renders correctly 1`] = `
             <Text
               style={
                 {
+                  "color": "#FFFFFF",
                   "fontFamily": "Inter-Regular",
                   "fontSize": 16,
                   "lineHeight": 24,

--- a/src/components/__snapshots__/FullscreenCTA.test.tsx.snap
+++ b/src/components/__snapshots__/FullscreenCTA.test.tsx.snap
@@ -35,6 +35,7 @@ exports[`FullscreenCTA renders correctly 1`] = `
     <Text
       style={
         {
+          "color": "#FFFFFF",
           "fontFamily": "Inter-Bold",
           "fontSize": 24,
           "lineHeight": 32,
@@ -46,6 +47,7 @@ exports[`FullscreenCTA renders correctly 1`] = `
     <Text
       style={
         {
+          "color": "#FFFFFF",
           "fontFamily": "Inter-Bold",
           "fontSize": 20,
           "lineHeight": 28,
@@ -63,6 +65,7 @@ exports[`FullscreenCTA renders correctly 1`] = `
         {
           "backgroundColor": "rgba(238, 238, 238, 0.75)",
           "borderRadius": 25,
+          "color": "#FFFFFF",
           "fontFamily": "Inter-Regular",
           "fontSize": 12,
           "lineHeight": 24,

--- a/src/components/__snapshots__/NumberKeypad.test.tsx.snap
+++ b/src/components/__snapshots__/NumberKeypad.test.tsx.snap
@@ -62,6 +62,7 @@ exports[`NumberKeypad renders correctly with decimal separator 1`] = `
         style={
           {
             "alignItems": "center",
+            "color": "#FFFFFF",
             "fontFamily": "Inter-Medium",
             "fontSize": 22,
             "justifyContent": "center",
@@ -116,6 +117,7 @@ exports[`NumberKeypad renders correctly with decimal separator 1`] = `
         style={
           {
             "alignItems": "center",
+            "color": "#FFFFFF",
             "fontFamily": "Inter-Medium",
             "fontSize": 22,
             "justifyContent": "center",
@@ -170,6 +172,7 @@ exports[`NumberKeypad renders correctly with decimal separator 1`] = `
         style={
           {
             "alignItems": "center",
+            "color": "#FFFFFF",
             "fontFamily": "Inter-Medium",
             "fontSize": 22,
             "justifyContent": "center",
@@ -235,6 +238,7 @@ exports[`NumberKeypad renders correctly with decimal separator 1`] = `
         style={
           {
             "alignItems": "center",
+            "color": "#FFFFFF",
             "fontFamily": "Inter-Medium",
             "fontSize": 22,
             "justifyContent": "center",
@@ -289,6 +293,7 @@ exports[`NumberKeypad renders correctly with decimal separator 1`] = `
         style={
           {
             "alignItems": "center",
+            "color": "#FFFFFF",
             "fontFamily": "Inter-Medium",
             "fontSize": 22,
             "justifyContent": "center",
@@ -343,6 +348,7 @@ exports[`NumberKeypad renders correctly with decimal separator 1`] = `
         style={
           {
             "alignItems": "center",
+            "color": "#FFFFFF",
             "fontFamily": "Inter-Medium",
             "fontSize": 22,
             "justifyContent": "center",
@@ -408,6 +414,7 @@ exports[`NumberKeypad renders correctly with decimal separator 1`] = `
         style={
           {
             "alignItems": "center",
+            "color": "#FFFFFF",
             "fontFamily": "Inter-Medium",
             "fontSize": 22,
             "justifyContent": "center",
@@ -462,6 +469,7 @@ exports[`NumberKeypad renders correctly with decimal separator 1`] = `
         style={
           {
             "alignItems": "center",
+            "color": "#FFFFFF",
             "fontFamily": "Inter-Medium",
             "fontSize": 22,
             "justifyContent": "center",
@@ -516,6 +524,7 @@ exports[`NumberKeypad renders correctly with decimal separator 1`] = `
         style={
           {
             "alignItems": "center",
+            "color": "#FFFFFF",
             "fontFamily": "Inter-Medium",
             "fontSize": 22,
             "justifyContent": "center",
@@ -580,6 +589,7 @@ exports[`NumberKeypad renders correctly with decimal separator 1`] = `
         style={
           {
             "alignItems": "center",
+            "color": "#FFFFFF",
             "fontFamily": "Inter-Medium",
             "fontSize": 22,
             "justifyContent": "center",
@@ -634,6 +644,7 @@ exports[`NumberKeypad renders correctly with decimal separator 1`] = `
         style={
           {
             "alignItems": "center",
+            "color": "#FFFFFF",
             "fontFamily": "Inter-Medium",
             "fontSize": 22,
             "justifyContent": "center",
@@ -687,6 +698,7 @@ exports[`NumberKeypad renders correctly with decimal separator 1`] = `
         style={
           {
             "alignItems": "center",
+            "color": "#FFFFFF",
             "fontFamily": "Inter-Medium",
             "fontSize": 22,
             "justifyContent": "center",
@@ -786,6 +798,7 @@ exports[`NumberKeypad renders correctly without decimal separator 1`] = `
         style={
           {
             "alignItems": "center",
+            "color": "#FFFFFF",
             "fontFamily": "Inter-Medium",
             "fontSize": 22,
             "justifyContent": "center",
@@ -840,6 +853,7 @@ exports[`NumberKeypad renders correctly without decimal separator 1`] = `
         style={
           {
             "alignItems": "center",
+            "color": "#FFFFFF",
             "fontFamily": "Inter-Medium",
             "fontSize": 22,
             "justifyContent": "center",
@@ -894,6 +908,7 @@ exports[`NumberKeypad renders correctly without decimal separator 1`] = `
         style={
           {
             "alignItems": "center",
+            "color": "#FFFFFF",
             "fontFamily": "Inter-Medium",
             "fontSize": 22,
             "justifyContent": "center",
@@ -959,6 +974,7 @@ exports[`NumberKeypad renders correctly without decimal separator 1`] = `
         style={
           {
             "alignItems": "center",
+            "color": "#FFFFFF",
             "fontFamily": "Inter-Medium",
             "fontSize": 22,
             "justifyContent": "center",
@@ -1013,6 +1029,7 @@ exports[`NumberKeypad renders correctly without decimal separator 1`] = `
         style={
           {
             "alignItems": "center",
+            "color": "#FFFFFF",
             "fontFamily": "Inter-Medium",
             "fontSize": 22,
             "justifyContent": "center",
@@ -1067,6 +1084,7 @@ exports[`NumberKeypad renders correctly without decimal separator 1`] = `
         style={
           {
             "alignItems": "center",
+            "color": "#FFFFFF",
             "fontFamily": "Inter-Medium",
             "fontSize": 22,
             "justifyContent": "center",
@@ -1132,6 +1150,7 @@ exports[`NumberKeypad renders correctly without decimal separator 1`] = `
         style={
           {
             "alignItems": "center",
+            "color": "#FFFFFF",
             "fontFamily": "Inter-Medium",
             "fontSize": 22,
             "justifyContent": "center",
@@ -1186,6 +1205,7 @@ exports[`NumberKeypad renders correctly without decimal separator 1`] = `
         style={
           {
             "alignItems": "center",
+            "color": "#FFFFFF",
             "fontFamily": "Inter-Medium",
             "fontSize": 22,
             "justifyContent": "center",
@@ -1240,6 +1260,7 @@ exports[`NumberKeypad renders correctly without decimal separator 1`] = `
         style={
           {
             "alignItems": "center",
+            "color": "#FFFFFF",
             "fontFamily": "Inter-Medium",
             "fontSize": 22,
             "justifyContent": "center",
@@ -1268,6 +1289,7 @@ exports[`NumberKeypad renders correctly without decimal separator 1`] = `
       style={
         {
           "alignItems": "center",
+          "color": "#FFFFFF",
           "fontFamily": "Inter-Medium",
           "fontSize": 22,
           "justifyContent": "center",
@@ -1319,6 +1341,7 @@ exports[`NumberKeypad renders correctly without decimal separator 1`] = `
         style={
           {
             "alignItems": "center",
+            "color": "#FFFFFF",
             "fontFamily": "Inter-Medium",
             "fontSize": 22,
             "justifyContent": "center",
@@ -1372,6 +1395,7 @@ exports[`NumberKeypad renders correctly without decimal separator 1`] = `
         style={
           {
             "alignItems": "center",
+            "color": "#FFFFFF",
             "fontFamily": "Inter-Medium",
             "fontSize": 22,
             "justifyContent": "center",

--- a/src/components/__snapshots__/SelectionOption.test.tsx.snap
+++ b/src/components/__snapshots__/SelectionOption.test.tsx.snap
@@ -84,6 +84,7 @@ exports[`renders selected correctly 1`] = `
       numberOfLines={1}
       style={
         {
+          "color": "#FFFFFF",
           "flex": 1,
           "fontFamily": "Inter-Regular",
           "fontSize": 16,
@@ -182,6 +183,7 @@ exports[`renders unselected correctly 1`] = `
       numberOfLines={1}
       style={
         {
+          "color": "#FFFFFF",
           "flex": 1,
           "fontFamily": "Inter-Regular",
           "fontSize": 16,

--- a/src/components/__snapshots__/SmartTopAlert.test.tsx.snap
+++ b/src/components/__snapshots__/SmartTopAlert.test.tsx.snap
@@ -56,6 +56,7 @@ exports[`SmartTopAlert renders correctly 1`] = `
       style={
         [
           {
+            "color": "#FFFFFF",
             "fontFamily": "Inter-Regular",
             "fontSize": 14,
             "lineHeight": 20,
@@ -73,6 +74,7 @@ exports[`SmartTopAlert renders correctly 1`] = `
         style={
           [
             {
+              "color": "#FFFFFF",
               "fontFamily": "Inter-Medium",
               "fontSize": 14,
               "lineHeight": 20,

--- a/src/components/__snapshots__/TextInputWithButtons.test.tsx.snap
+++ b/src/components/__snapshots__/TextInputWithButtons.test.tsx.snap
@@ -19,6 +19,7 @@ exports[`TextInputWithButtons renders correctly 1`] = `
     style={
       [
         {
+          "color": "#FFFFFF",
           "flex": 1,
           "fontFamily": "Inter-Regular",
           "fontSize": 16,

--- a/src/earn/EarnInfoScreen.tsx
+++ b/src/earn/EarnInfoScreen.tsx
@@ -146,7 +146,6 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   title: {
-    color: Colors.white,
     textAlign: 'center',
     marginBottom: Spacing.Thick24,
     ...typeScale.titleLarge,
@@ -159,15 +158,12 @@ const styles = StyleSheet.create({
     gap: Spacing.Regular16,
   },
   detailsItemTitle: {
-    color: Colors.white,
     ...typeScale.labelSemiBoldMedium,
   },
   detailsItemSubtitle: {
-    color: Colors.white,
     ...typeScale.bodySmall,
   },
   detailsItemFootnote: {
-    color: Colors.white,
     marginTop: Spacing.Smallest8,
     ...typeScale.bodyXSmall,
   },

--- a/src/earn/PoolCard.tsx
+++ b/src/earn/PoolCard.tsx
@@ -156,11 +156,9 @@ const styles = StyleSheet.create({
     marginLeft: Spacing.Smallest8,
   },
   titleTokens: {
-    color: Colors.white,
     ...typeScale.labelSemiBoldSmall,
   },
   titleNetwork: {
-    color: Colors.white,
     ...typeScale.bodyXSmall,
   },
   keyValueContainer: {
@@ -171,21 +169,19 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
   },
   keyText: {
-    color: Colors.lightBlue,
     ...typeScale.bodySmall,
+    color: Colors.lightBlue,
   },
   valueText: {
-    color: Colors.white,
     ...typeScale.bodySmall,
   },
   valueTextBold: {
-    color: Colors.white,
     ...typeScale.labelSemiBoldSmall,
   },
   poweredByText: {
-    color: Colors.lightBlue,
     ...typeScale.bodyXSmall,
     alignSelf: 'center',
+    color: Colors.lightBlue,
   },
   withBalanceContainer: {
     borderTopWidth: 1,

--- a/src/fiatExchanges/__snapshots__/CashInSuccess.test.tsx.snap
+++ b/src/fiatExchanges/__snapshots__/CashInSuccess.test.tsx.snap
@@ -37,6 +37,7 @@ exports[`CashinInSuccess renders correctly with a provider 1`] = `
     <Text
       style={
         {
+          "color": "#FFFFFF",
           "fontFamily": "Inter-Medium",
           "fontSize": 18,
           "lineHeight": 28,
@@ -50,6 +51,7 @@ exports[`CashinInSuccess renders correctly with a provider 1`] = `
     <Text
       style={
         {
+          "color": "#FFFFFF",
           "fontFamily": "Inter-Regular",
           "fontSize": 16,
           "lineHeight": 24,
@@ -207,6 +209,7 @@ exports[`CashinInSuccess renders correctly without a provider 1`] = `
     <Text
       style={
         {
+          "color": "#FFFFFF",
           "fontFamily": "Inter-Medium",
           "fontSize": 18,
           "lineHeight": 28,
@@ -220,6 +223,7 @@ exports[`CashinInSuccess renders correctly without a provider 1`] = `
     <Text
       style={
         {
+          "color": "#FFFFFF",
           "fontFamily": "Inter-Regular",
           "fontSize": 16,
           "lineHeight": 24,

--- a/src/fiatExchanges/__snapshots__/FiatExchangeAmount.test.tsx.snap
+++ b/src/fiatExchanges/__snapshots__/FiatExchangeAmount.test.tsx.snap
@@ -70,6 +70,7 @@ exports[`FiatExchangeAmount cashIn renders correctly with EUR as app currency 1`
           <Text
             style={
               {
+                "color": "#FFFFFF",
                 "fontFamily": "Inter-Medium",
                 "fontSize": 16,
                 "lineHeight": 24,
@@ -89,6 +90,7 @@ exports[`FiatExchangeAmount cashIn renders correctly with EUR as app currency 1`
           style={
             [
               {
+                "color": "#FFFFFF",
                 "flex": 1,
                 "fontFamily": "Inter-Regular",
                 "fontSize": 19,
@@ -291,6 +293,7 @@ exports[`FiatExchangeAmount cashIn renders correctly with USD as app currency 1`
           <Text
             style={
               {
+                "color": "#FFFFFF",
                 "fontFamily": "Inter-Medium",
                 "fontSize": 16,
                 "lineHeight": 24,
@@ -310,6 +313,7 @@ exports[`FiatExchangeAmount cashIn renders correctly with USD as app currency 1`
           style={
             [
               {
+                "color": "#FFFFFF",
                 "flex": 1,
                 "fontFamily": "Inter-Regular",
                 "fontSize": 19,

--- a/src/fiatExchanges/__snapshots__/ReviewFees.test.tsx.snap
+++ b/src/fiatExchanges/__snapshots__/ReviewFees.test.tsx.snap
@@ -69,6 +69,7 @@ exports[`ReviewFees renders correctly 1`] = `
     style={
       [
         {
+          "color": "#FFFFFF",
           "display": "flex",
           "flexDirection": "row",
           "fontFamily": "Inter-Regular",
@@ -84,6 +85,7 @@ exports[`ReviewFees renders correctly 1`] = `
       style={
         [
           {
+            "color": "#FFFFFF",
             "fontFamily": "Inter-Regular",
             "fontSize": 16,
             "lineHeight": 24,
@@ -100,6 +102,7 @@ exports[`ReviewFees renders correctly 1`] = `
       style={
         [
           {
+            "color": "#FFFFFF",
             "fontFamily": "Inter-Regular",
             "fontSize": 16,
             "lineHeight": 24,
@@ -126,6 +129,7 @@ exports[`ReviewFees renders correctly 1`] = `
     style={
       [
         {
+          "color": "#FFFFFF",
           "display": "flex",
           "flexDirection": "row",
           "fontFamily": "Inter-Regular",
@@ -141,6 +145,7 @@ exports[`ReviewFees renders correctly 1`] = `
       style={
         [
           {
+            "color": "#FFFFFF",
             "fontFamily": "Inter-Regular",
             "fontSize": 16,
             "lineHeight": 24,
@@ -157,6 +162,7 @@ exports[`ReviewFees renders correctly 1`] = `
       style={
         [
           {
+            "color": "#FFFFFF",
             "fontFamily": "Inter-Regular",
             "fontSize": 16,
             "lineHeight": 24,
@@ -203,6 +209,7 @@ exports[`ReviewFees renders correctly 1`] = `
     style={
       [
         {
+          "color": "#FFFFFF",
           "display": "flex",
           "flexDirection": "row",
           "fontFamily": "Inter-Regular",
@@ -218,6 +225,7 @@ exports[`ReviewFees renders correctly 1`] = `
       style={
         [
           {
+            "color": "#FFFFFF",
             "fontFamily": "Inter-Regular",
             "fontSize": 16,
             "lineHeight": 24,
@@ -231,6 +239,7 @@ exports[`ReviewFees renders correctly 1`] = `
       style={
         [
           {
+            "color": "#FFFFFF",
             "fontFamily": "Inter-Regular",
             "fontSize": 16,
             "lineHeight": 24,
@@ -258,6 +267,7 @@ exports[`ReviewFees renders correctly 1`] = `
     style={
       [
         {
+          "color": "#FFFFFF",
           "display": "flex",
           "flexDirection": "row",
           "fontFamily": "Inter-Regular",
@@ -283,6 +293,7 @@ exports[`ReviewFees renders correctly 1`] = `
         style={
           [
             {
+              "color": "#FFFFFF",
               "fontFamily": "Inter-Regular",
               "fontSize": 16,
               "lineHeight": 24,
@@ -373,13 +384,14 @@ exports[`ReviewFees renders correctly 1`] = `
           [
             [
               {
+                "color": "#FFFFFF",
                 "fontFamily": "Inter-Regular",
                 "fontSize": 16,
                 "lineHeight": 24,
               },
             ],
             {
-              "color": undefined,
+              "color": "#FFFFFF",
             },
           ]
         }
@@ -394,6 +406,7 @@ exports[`ReviewFees renders correctly 1`] = `
     style={
       [
         {
+          "color": "#FFFFFF",
           "display": "flex",
           "flexDirection": "row",
           "fontFamily": "Inter-Regular",
@@ -409,11 +422,13 @@ exports[`ReviewFees renders correctly 1`] = `
       style={
         [
           {
+            "color": "#FFFFFF",
             "fontFamily": "Inter-Regular",
             "fontSize": 16,
             "lineHeight": 24,
           },
           {
+            "color": "#FFFFFF",
             "fontFamily": "Inter-SemiBold",
             "fontSize": 16,
             "lineHeight": 24,
@@ -427,11 +442,13 @@ exports[`ReviewFees renders correctly 1`] = `
       style={
         [
           {
+            "color": "#FFFFFF",
             "fontFamily": "Inter-Regular",
             "fontSize": 16,
             "lineHeight": 24,
           },
           {
+            "color": "#FFFFFF",
             "fontFamily": "Inter-SemiBold",
             "fontSize": 16,
             "lineHeight": 24,
@@ -444,13 +461,14 @@ exports[`ReviewFees renders correctly 1`] = `
           [
             [
               {
+                "color": "#FFFFFF",
                 "fontFamily": "Inter-SemiBold",
                 "fontSize": 16,
                 "lineHeight": 24,
               },
             ],
             {
-              "color": undefined,
+              "color": "#FFFFFF",
             },
           ]
         }
@@ -533,6 +551,7 @@ exports[`ReviewFees renders correctly 2`] = `
     style={
       [
         {
+          "color": "#FFFFFF",
           "display": "flex",
           "flexDirection": "row",
           "fontFamily": "Inter-Regular",
@@ -548,6 +567,7 @@ exports[`ReviewFees renders correctly 2`] = `
       style={
         [
           {
+            "color": "#FFFFFF",
             "fontFamily": "Inter-Regular",
             "fontSize": 16,
             "lineHeight": 24,
@@ -564,6 +584,7 @@ exports[`ReviewFees renders correctly 2`] = `
       style={
         [
           {
+            "color": "#FFFFFF",
             "fontFamily": "Inter-Regular",
             "fontSize": 16,
             "lineHeight": 24,
@@ -590,6 +611,7 @@ exports[`ReviewFees renders correctly 2`] = `
     style={
       [
         {
+          "color": "#FFFFFF",
           "display": "flex",
           "flexDirection": "row",
           "fontFamily": "Inter-Regular",
@@ -605,6 +627,7 @@ exports[`ReviewFees renders correctly 2`] = `
       style={
         [
           {
+            "color": "#FFFFFF",
             "fontFamily": "Inter-Regular",
             "fontSize": 16,
             "lineHeight": 24,
@@ -621,6 +644,7 @@ exports[`ReviewFees renders correctly 2`] = `
       style={
         [
           {
+            "color": "#FFFFFF",
             "fontFamily": "Inter-Regular",
             "fontSize": 16,
             "lineHeight": 24,
@@ -667,6 +691,7 @@ exports[`ReviewFees renders correctly 2`] = `
     style={
       [
         {
+          "color": "#FFFFFF",
           "display": "flex",
           "flexDirection": "row",
           "fontFamily": "Inter-Regular",
@@ -682,6 +707,7 @@ exports[`ReviewFees renders correctly 2`] = `
       style={
         [
           {
+            "color": "#FFFFFF",
             "fontFamily": "Inter-Regular",
             "fontSize": 16,
             "lineHeight": 24,
@@ -695,6 +721,7 @@ exports[`ReviewFees renders correctly 2`] = `
       style={
         [
           {
+            "color": "#FFFFFF",
             "fontFamily": "Inter-Regular",
             "fontSize": 16,
             "lineHeight": 24,
@@ -722,6 +749,7 @@ exports[`ReviewFees renders correctly 2`] = `
     style={
       [
         {
+          "color": "#FFFFFF",
           "display": "flex",
           "flexDirection": "row",
           "fontFamily": "Inter-Regular",
@@ -747,6 +775,7 @@ exports[`ReviewFees renders correctly 2`] = `
         style={
           [
             {
+              "color": "#FFFFFF",
               "fontFamily": "Inter-Regular",
               "fontSize": 16,
               "lineHeight": 24,
@@ -846,6 +875,7 @@ exports[`ReviewFees renders correctly 2`] = `
     style={
       [
         {
+          "color": "#FFFFFF",
           "display": "flex",
           "flexDirection": "row",
           "fontFamily": "Inter-Regular",
@@ -861,11 +891,13 @@ exports[`ReviewFees renders correctly 2`] = `
       style={
         [
           {
+            "color": "#FFFFFF",
             "fontFamily": "Inter-Regular",
             "fontSize": 16,
             "lineHeight": 24,
           },
           {
+            "color": "#FFFFFF",
             "fontFamily": "Inter-SemiBold",
             "fontSize": 16,
             "lineHeight": 24,
@@ -879,11 +911,13 @@ exports[`ReviewFees renders correctly 2`] = `
       style={
         [
           {
+            "color": "#FFFFFF",
             "fontFamily": "Inter-Regular",
             "fontSize": 16,
             "lineHeight": 24,
           },
           {
+            "color": "#FFFFFF",
             "fontFamily": "Inter-SemiBold",
             "fontSize": 16,
             "lineHeight": 24,
@@ -896,13 +930,14 @@ exports[`ReviewFees renders correctly 2`] = `
           [
             [
               {
+                "color": "#FFFFFF",
                 "fontFamily": "Inter-SemiBold",
                 "fontSize": 16,
                 "lineHeight": 24,
               },
             ],
             {
-              "color": undefined,
+              "color": "#FFFFFF",
             },
           ]
         }

--- a/src/fiatExchanges/__snapshots__/SimplexScreen.test.tsx.snap
+++ b/src/fiatExchanges/__snapshots__/SimplexScreen.test.tsx.snap
@@ -89,6 +89,7 @@ exports[`SimplexScreen renders correctly 1`] = `
         style={
           [
             {
+              "color": "#FFFFFF",
               "display": "flex",
               "flexDirection": "row",
               "fontFamily": "Inter-Regular",
@@ -104,6 +105,7 @@ exports[`SimplexScreen renders correctly 1`] = `
           style={
             [
               {
+                "color": "#FFFFFF",
                 "fontFamily": "Inter-Regular",
                 "fontSize": 16,
                 "lineHeight": 24,
@@ -120,6 +122,7 @@ exports[`SimplexScreen renders correctly 1`] = `
           style={
             [
               {
+                "color": "#FFFFFF",
                 "fontFamily": "Inter-Regular",
                 "fontSize": 16,
                 "lineHeight": 24,
@@ -146,6 +149,7 @@ exports[`SimplexScreen renders correctly 1`] = `
         style={
           [
             {
+              "color": "#FFFFFF",
               "display": "flex",
               "flexDirection": "row",
               "fontFamily": "Inter-Regular",
@@ -161,6 +165,7 @@ exports[`SimplexScreen renders correctly 1`] = `
           style={
             [
               {
+                "color": "#FFFFFF",
                 "fontFamily": "Inter-Regular",
                 "fontSize": 16,
                 "lineHeight": 24,
@@ -177,6 +182,7 @@ exports[`SimplexScreen renders correctly 1`] = `
           style={
             [
               {
+                "color": "#FFFFFF",
                 "fontFamily": "Inter-Regular",
                 "fontSize": 16,
                 "lineHeight": 24,
@@ -223,6 +229,7 @@ exports[`SimplexScreen renders correctly 1`] = `
         style={
           [
             {
+              "color": "#FFFFFF",
               "display": "flex",
               "flexDirection": "row",
               "fontFamily": "Inter-Regular",
@@ -238,6 +245,7 @@ exports[`SimplexScreen renders correctly 1`] = `
           style={
             [
               {
+                "color": "#FFFFFF",
                 "fontFamily": "Inter-Regular",
                 "fontSize": 16,
                 "lineHeight": 24,
@@ -251,6 +259,7 @@ exports[`SimplexScreen renders correctly 1`] = `
           style={
             [
               {
+                "color": "#FFFFFF",
                 "fontFamily": "Inter-Regular",
                 "fontSize": 16,
                 "lineHeight": 24,
@@ -278,6 +287,7 @@ exports[`SimplexScreen renders correctly 1`] = `
         style={
           [
             {
+              "color": "#FFFFFF",
               "display": "flex",
               "flexDirection": "row",
               "fontFamily": "Inter-Regular",
@@ -303,6 +313,7 @@ exports[`SimplexScreen renders correctly 1`] = `
             style={
               [
                 {
+                  "color": "#FFFFFF",
                   "fontFamily": "Inter-Regular",
                   "fontSize": 16,
                   "lineHeight": 24,
@@ -393,13 +404,14 @@ exports[`SimplexScreen renders correctly 1`] = `
               [
                 [
                   {
+                    "color": "#FFFFFF",
                     "fontFamily": "Inter-Regular",
                     "fontSize": 16,
                     "lineHeight": 24,
                   },
                 ],
                 {
-                  "color": undefined,
+                  "color": "#FFFFFF",
                 },
               ]
             }
@@ -414,6 +426,7 @@ exports[`SimplexScreen renders correctly 1`] = `
         style={
           [
             {
+              "color": "#FFFFFF",
               "display": "flex",
               "flexDirection": "row",
               "fontFamily": "Inter-Regular",
@@ -429,11 +442,13 @@ exports[`SimplexScreen renders correctly 1`] = `
           style={
             [
               {
+                "color": "#FFFFFF",
                 "fontFamily": "Inter-Regular",
                 "fontSize": 16,
                 "lineHeight": 24,
               },
               {
+                "color": "#FFFFFF",
                 "fontFamily": "Inter-SemiBold",
                 "fontSize": 16,
                 "lineHeight": 24,
@@ -447,11 +462,13 @@ exports[`SimplexScreen renders correctly 1`] = `
           style={
             [
               {
+                "color": "#FFFFFF",
                 "fontFamily": "Inter-Regular",
                 "fontSize": 16,
                 "lineHeight": 24,
               },
               {
+                "color": "#FFFFFF",
                 "fontFamily": "Inter-SemiBold",
                 "fontSize": 16,
                 "lineHeight": 24,
@@ -464,13 +481,14 @@ exports[`SimplexScreen renders correctly 1`] = `
               [
                 [
                   {
+                    "color": "#FFFFFF",
                     "fontFamily": "Inter-SemiBold",
                     "fontSize": 16,
                     "lineHeight": 24,
                   },
                 ],
                 {
-                  "color": undefined,
+                  "color": "#FFFFFF",
                 },
               ]
             }
@@ -658,6 +676,7 @@ exports[`SimplexScreen renders correctly 2`] = `
         style={
           [
             {
+              "color": "#FFFFFF",
               "display": "flex",
               "flexDirection": "row",
               "fontFamily": "Inter-Regular",
@@ -673,6 +692,7 @@ exports[`SimplexScreen renders correctly 2`] = `
           style={
             [
               {
+                "color": "#FFFFFF",
                 "fontFamily": "Inter-Regular",
                 "fontSize": 16,
                 "lineHeight": 24,
@@ -689,6 +709,7 @@ exports[`SimplexScreen renders correctly 2`] = `
           style={
             [
               {
+                "color": "#FFFFFF",
                 "fontFamily": "Inter-Regular",
                 "fontSize": 16,
                 "lineHeight": 24,
@@ -715,6 +736,7 @@ exports[`SimplexScreen renders correctly 2`] = `
         style={
           [
             {
+              "color": "#FFFFFF",
               "display": "flex",
               "flexDirection": "row",
               "fontFamily": "Inter-Regular",
@@ -730,6 +752,7 @@ exports[`SimplexScreen renders correctly 2`] = `
           style={
             [
               {
+                "color": "#FFFFFF",
                 "fontFamily": "Inter-Regular",
                 "fontSize": 16,
                 "lineHeight": 24,
@@ -746,6 +769,7 @@ exports[`SimplexScreen renders correctly 2`] = `
           style={
             [
               {
+                "color": "#FFFFFF",
                 "fontFamily": "Inter-Regular",
                 "fontSize": 16,
                 "lineHeight": 24,
@@ -792,6 +816,7 @@ exports[`SimplexScreen renders correctly 2`] = `
         style={
           [
             {
+              "color": "#FFFFFF",
               "display": "flex",
               "flexDirection": "row",
               "fontFamily": "Inter-Regular",
@@ -807,6 +832,7 @@ exports[`SimplexScreen renders correctly 2`] = `
           style={
             [
               {
+                "color": "#FFFFFF",
                 "fontFamily": "Inter-Regular",
                 "fontSize": 16,
                 "lineHeight": 24,
@@ -820,6 +846,7 @@ exports[`SimplexScreen renders correctly 2`] = `
           style={
             [
               {
+                "color": "#FFFFFF",
                 "fontFamily": "Inter-Regular",
                 "fontSize": 16,
                 "lineHeight": 24,
@@ -847,6 +874,7 @@ exports[`SimplexScreen renders correctly 2`] = `
         style={
           [
             {
+              "color": "#FFFFFF",
               "display": "flex",
               "flexDirection": "row",
               "fontFamily": "Inter-Regular",
@@ -872,6 +900,7 @@ exports[`SimplexScreen renders correctly 2`] = `
             style={
               [
                 {
+                  "color": "#FFFFFF",
                   "fontFamily": "Inter-Regular",
                   "fontSize": 16,
                   "lineHeight": 24,
@@ -962,13 +991,14 @@ exports[`SimplexScreen renders correctly 2`] = `
               [
                 [
                   {
+                    "color": "#FFFFFF",
                     "fontFamily": "Inter-Regular",
                     "fontSize": 16,
                     "lineHeight": 24,
                   },
                 ],
                 {
-                  "color": undefined,
+                  "color": "#FFFFFF",
                 },
               ]
             }
@@ -983,6 +1013,7 @@ exports[`SimplexScreen renders correctly 2`] = `
         style={
           [
             {
+              "color": "#FFFFFF",
               "display": "flex",
               "flexDirection": "row",
               "fontFamily": "Inter-Regular",
@@ -998,11 +1029,13 @@ exports[`SimplexScreen renders correctly 2`] = `
           style={
             [
               {
+                "color": "#FFFFFF",
                 "fontFamily": "Inter-Regular",
                 "fontSize": 16,
                 "lineHeight": 24,
               },
               {
+                "color": "#FFFFFF",
                 "fontFamily": "Inter-SemiBold",
                 "fontSize": 16,
                 "lineHeight": 24,
@@ -1016,11 +1049,13 @@ exports[`SimplexScreen renders correctly 2`] = `
           style={
             [
               {
+                "color": "#FFFFFF",
                 "fontFamily": "Inter-Regular",
                 "fontSize": 16,
                 "lineHeight": 24,
               },
               {
+                "color": "#FFFFFF",
                 "fontFamily": "Inter-SemiBold",
                 "fontSize": 16,
                 "lineHeight": 24,
@@ -1033,13 +1068,14 @@ exports[`SimplexScreen renders correctly 2`] = `
               [
                 [
                   {
+                    "color": "#FFFFFF",
                     "fontFamily": "Inter-SemiBold",
                     "fontSize": 16,
                     "lineHeight": 24,
                   },
                 ],
                 {
-                  "color": undefined,
+                  "color": "#FFFFFF",
                 },
               ]
             }

--- a/src/home/__snapshots__/NotificationBox.test.tsx.snap
+++ b/src/home/__snapshots__/NotificationBox.test.tsx.snap
@@ -70,6 +70,7 @@ exports[`NotificationBox renders correctly for with all notifications 1`] = `
                 <Text
                   style={
                     {
+                      "color": "#FFFFFF",
                       "fontFamily": "Inter-Regular",
                       "fontSize": 18,
                       "lineHeight": 28,
@@ -276,6 +277,7 @@ exports[`NotificationBox renders correctly for with all notifications 1`] = `
                 <Text
                   style={
                     {
+                      "color": "#FFFFFF",
                       "fontFamily": "Inter-Regular",
                       "fontSize": 18,
                       "lineHeight": 28,
@@ -497,6 +499,7 @@ exports[`NotificationBox renders correctly for with all notifications 1`] = `
                 <Text
                   style={
                     {
+                      "color": "#FFFFFF",
                       "fontFamily": "Inter-Regular",
                       "fontSize": 18,
                       "lineHeight": 28,
@@ -692,6 +695,7 @@ exports[`NotificationBox renders correctly for with all notifications 1`] = `
                 <Text
                   style={
                     {
+                      "color": "#FFFFFF",
                       "fontFamily": "Inter-Regular",
                       "fontSize": 18,
                       "lineHeight": 28,

--- a/src/keylessBackup/KeylessBackupPhoneCodeInput.tsx
+++ b/src/keylessBackup/KeylessBackupPhoneCodeInput.tsx
@@ -217,8 +217,8 @@ const styles = StyleSheet.create({
     marginBottom: Spacing.Regular16,
   },
   help: {
-    color: colors.accent,
     ...typeScale.labelSemiBoldMedium,
+    color: colors.accent,
   },
   bottomSheetTitle: {
     ...typeScale.titleSmall,

--- a/src/keylessBackup/KeylessBackupProgress.tsx
+++ b/src/keylessBackup/KeylessBackupProgress.tsx
@@ -483,8 +483,8 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   help: {
-    color: colors.accent,
     ...typeScale.labelSemiBoldMedium,
+    color: colors.accent,
   },
 })
 

--- a/src/send/__snapshots__/SendConfirmation.test.tsx.snap
+++ b/src/send/__snapshots__/SendConfirmation.test.tsx.snap
@@ -318,6 +318,7 @@ exports[`SendConfirmation renders correctly 1`] = `
                   "lineHeight": 24,
                 },
                 {
+                  "color": "#FFFFFF",
                   "fontFamily": "Inter-Regular",
                   "fontSize": 16,
                   "lineHeight": 24,
@@ -339,6 +340,7 @@ exports[`SendConfirmation renders correctly 1`] = `
                 "lineHeight": 24,
               },
               {
+                "color": "#FFFFFF",
                 "fontFamily": "Inter-Regular",
                 "fontSize": 16,
                 "lineHeight": 24,
@@ -454,6 +456,7 @@ exports[`SendConfirmation renders correctly 1`] = `
                   "lineHeight": 24,
                 },
                 {
+                  "color": "#FFFFFF",
                   "fontFamily": "Inter-SemiBold",
                   "fontSize": 16,
                   "lineHeight": 24,
@@ -475,6 +478,7 @@ exports[`SendConfirmation renders correctly 1`] = `
                 "lineHeight": 24,
               },
               {
+                "color": "#FFFFFF",
                 "fontFamily": "Inter-SemiBold",
                 "fontSize": 16,
                 "lineHeight": 24,

--- a/src/send/__snapshots__/ValidateRecipientAccount.test.tsx.snap
+++ b/src/send/__snapshots__/ValidateRecipientAccount.test.tsx.snap
@@ -18,6 +18,7 @@ exports[`ValidateRecipientAccount renders correctly when full validation require
         <Text
           style={
             {
+              "color": "#FFFFFF",
               "fontFamily": "Inter-Bold",
               "fontSize": 20,
               "lineHeight": 28,
@@ -33,6 +34,7 @@ exports[`ValidateRecipientAccount renders correctly when full validation require
             <Text
               style={
                 {
+                  "color": "#FFFFFF",
                   "fontFamily": "Inter-Regular",
                   "fontSize": 16,
                   "lineHeight": 24,
@@ -45,6 +47,7 @@ exports[`ValidateRecipientAccount renders correctly when full validation require
             <Text
               style={
                 {
+                  "color": "#FFFFFF",
                   "fontFamily": "Inter-Regular",
                   "fontSize": 16,
                   "lineHeight": 24,
@@ -57,6 +60,7 @@ exports[`ValidateRecipientAccount renders correctly when full validation require
             <Text
               style={
                 {
+                  "color": "#FFFFFF",
                   "fontFamily": "Inter-SemiBold",
                   "fontSize": 14,
                   "lineHeight": 20,
@@ -249,6 +253,7 @@ exports[`ValidateRecipientAccount renders correctly when full validation require
           onPress={[Function]}
           style={
             {
+              "color": "#FFFFFF",
               "fontFamily": "Inter-Regular",
               "fontSize": 14,
               "lineHeight": 20,
@@ -326,6 +331,7 @@ exports[`ValidateRecipientAccount renders correctly when partial validation requ
         <Text
           style={
             {
+              "color": "#FFFFFF",
               "fontFamily": "Inter-Bold",
               "fontSize": 20,
               "lineHeight": 28,
@@ -341,6 +347,7 @@ exports[`ValidateRecipientAccount renders correctly when partial validation requ
             <Text
               style={
                 {
+                  "color": "#FFFFFF",
                   "fontFamily": "Inter-Regular",
                   "fontSize": 16,
                   "lineHeight": 24,
@@ -353,6 +360,7 @@ exports[`ValidateRecipientAccount renders correctly when partial validation requ
             <Text
               style={
                 {
+                  "color": "#FFFFFF",
                   "fontFamily": "Inter-SemiBold",
                   "fontSize": 14,
                   "lineHeight": 20,
@@ -746,6 +754,7 @@ exports[`ValidateRecipientAccount renders correctly when partial validation requ
           onPress={[Function]}
           style={
             {
+              "color": "#FFFFFF",
               "fontFamily": "Inter-Regular",
               "fontSize": 14,
               "lineHeight": 20,

--- a/src/shared/__snapshots__/DisconnectBanner.test.tsx.snap
+++ b/src/shared/__snapshots__/DisconnectBanner.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`renders banner when app is disconnected 1`] = `
   style={
     [
       {
+        "color": "#FFFFFF",
         "fontFamily": "Inter-Regular",
         "fontSize": 14,
         "lineHeight": undefined,
@@ -14,6 +15,7 @@ exports[`renders banner when app is disconnected 1`] = `
         "color": "#B7B9C9",
       },
       {
+        "color": "#FFFFFF",
         "fontFamily": "Inter-SemiBold",
         "fontSize": 16,
         "lineHeight": 24,

--- a/src/statsig/index.test.ts
+++ b/src/statsig/index.test.ts
@@ -104,7 +104,7 @@ describe('Statsig helpers', () => {
       const defaultValues = { param1: 'defaultValue1', param2: 'defaultValue2' }
       const experimentName = 'mock_experiment_name' as StatsigExperiments
       const output = getExperimentParams({ experimentName, defaultValues })
-      expect(Logger.warn).not.toHaveBeenCalled() // TODO: reenable when turning on statsig
+      expect(Logger.warn).toHaveBeenCalled()
       expect(Statsig.getExperiment).toHaveBeenCalledWith(experimentName)
       expect(getMock).toHaveBeenCalledWith('param1', 'defaultValue1')
       expect(getMock).toHaveBeenCalledWith('param2', 'defaultValue2')
@@ -261,7 +261,7 @@ describe('Statsig helpers', () => {
       const defaultValues = { param1: 'defaultValue1', param2: 'defaultValue2' }
       const configName = 'mock_config' as StatsigDynamicConfigs
       const output = getDynamicConfigParams({ configName, defaultValues })
-      expect(Logger.warn).toHaveBeenCalled()
+      expect(Logger.warn).not.toHaveBeenCalled() // TODO: reenable when turning on statsig
       expect(Statsig.getConfig).toHaveBeenCalledWith(configName)
       expect(getMock).toHaveBeenCalledWith('param1', 'defaultValue1')
       expect(getMock).toHaveBeenCalledWith('param2', 'defaultValue2')

--- a/src/statsig/index.test.ts
+++ b/src/statsig/index.test.ts
@@ -104,7 +104,7 @@ describe('Statsig helpers', () => {
       const defaultValues = { param1: 'defaultValue1', param2: 'defaultValue2' }
       const experimentName = 'mock_experiment_name' as StatsigExperiments
       const output = getExperimentParams({ experimentName, defaultValues })
-      // expect(Logger.warn).toHaveBeenCalled()
+      expect(Logger.warn).not.toHaveBeenCalled() // TODO: reenable when turning on statsig
       expect(Statsig.getExperiment).toHaveBeenCalledWith(experimentName)
       expect(getMock).toHaveBeenCalledWith('param1', 'defaultValue1')
       expect(getMock).toHaveBeenCalledWith('param2', 'defaultValue2')

--- a/src/statsig/index.test.ts
+++ b/src/statsig/index.test.ts
@@ -104,7 +104,7 @@ describe('Statsig helpers', () => {
       const defaultValues = { param1: 'defaultValue1', param2: 'defaultValue2' }
       const experimentName = 'mock_experiment_name' as StatsigExperiments
       const output = getExperimentParams({ experimentName, defaultValues })
-      expect(Logger.warn).toHaveBeenCalled()
+      // expect(Logger.warn).toHaveBeenCalled()
       expect(Statsig.getExperiment).toHaveBeenCalledWith(experimentName)
       expect(getMock).toHaveBeenCalledWith('param1', 'defaultValue1')
       expect(getMock).toHaveBeenCalledWith('param2', 'defaultValue2')

--- a/src/statsig/index.ts
+++ b/src/statsig/index.ts
@@ -74,11 +74,11 @@ function _getDynamicConfigParams<T extends Record<string, StatsigParameter>>({
   try {
     const config = Statsig.getConfig(configName)
     if (!isE2EEnv && config.getEvaluationDetails().reason === EvaluationReason.Uninitialized) {
-      Logger.warn(
-        TAG,
-        'getDynamicConfigParams: SDK is uninitialized when getting experiment',
-        config
-      )
+      // Logger.warn(
+      //   TAG,
+      //   'getDynamicConfigParams: SDK is uninitialized when getting experiment',
+      //   config
+      // )
     }
     return getParams({ config, defaultValues })
   } catch (error) {

--- a/src/styles/colors.tsx
+++ b/src/styles/colors.tsx
@@ -9,6 +9,8 @@ enum Colors {
   lightBlue = '#B7B9C9',
   blue200 = '#2D3154',
   blue100 = '#363B63',
+  text = '#FFFFFF',
+  background = '#242843',
 
   // other
   gray5 = '#505050',

--- a/src/styles/fonts.tsx
+++ b/src/styles/fonts.tsx
@@ -1,4 +1,5 @@
 import { StyleSheet } from 'react-native'
+import Colors from 'src/styles/colors'
 
 const Inter = {
   Regular: 'Inter-Regular',
@@ -16,107 +17,127 @@ export const typeScale = StyleSheet.create({
     fontSize: 80,
     lineHeight: 80,
     letterSpacing: -2.4,
+    color: Colors.text,
   },
   displayMedium: {
     fontFamily: Inter.Bold,
     fontSize: 56,
     lineHeight: 64,
     letterSpacing: -1.12,
+    color: Colors.text,
   },
   displaySmall: {
     fontFamily: Inter.Bold,
     fontSize: 40,
     lineHeight: 48,
     letterSpacing: -0.8,
+    color: Colors.text,
   },
   titleLarge: {
     fontFamily: Inter.Bold,
     fontSize: 32,
     lineHeight: 40,
     letterSpacing: -0.32,
+    color: Colors.text,
   },
   titleMedium: {
     fontFamily: Inter.Bold,
     fontSize: 24,
     lineHeight: 32,
+    color: Colors.text,
   },
   titleSmall: {
     fontFamily: Inter.Bold,
     fontSize: 20,
     lineHeight: 28,
+    color: Colors.text,
   },
   labelSemiBoldLarge: {
     fontFamily: Inter.SemiBold,
     fontSize: 18,
     lineHeight: 28,
+    color: Colors.text,
   },
   labelSemiBoldMedium: {
     fontFamily: Inter.SemiBold,
     fontSize: 16,
     lineHeight: 24,
+    color: Colors.text,
   },
   labelSemiBoldSmall: {
     fontFamily: Inter.SemiBold,
     fontSize: 14,
     lineHeight: 20,
+    color: Colors.text,
   },
   labelSemiBoldXSmall: {
     fontFamily: Inter.SemiBold,
     fontSize: 12,
     lineHeight: 16,
+    color: Colors.text,
   },
   labelLarge: {
     fontFamily: Inter.Medium,
     fontSize: 18,
     lineHeight: 28,
+    color: Colors.text,
   },
   labelMedium: {
     fontFamily: Inter.Medium,
     fontSize: 16,
     lineHeight: 24,
+    color: Colors.text,
   },
   labelSmall: {
     fontFamily: Inter.Medium,
     fontSize: 14,
     lineHeight: 20,
+    color: Colors.text,
   },
   labelXSmall: {
     fontFamily: Inter.Medium,
     fontSize: 12,
     lineHeight: 16,
     letterSpacing: 0.12,
+    color: Colors.text,
   },
   labelXXSmall: {
     fontFamily: Inter.Medium,
     fontSize: 10,
     lineHeight: 12,
     letterSpacing: 0.2,
+    color: Colors.text,
   },
   bodyLarge: {
     fontFamily: Inter.Regular,
     fontSize: 18,
     lineHeight: 28,
+    color: Colors.text,
   },
   bodyMedium: {
     fontFamily: Inter.Regular,
     fontSize: 16,
     lineHeight: 24,
+    color: Colors.text,
   },
   bodySmall: {
     fontFamily: Inter.Regular,
     fontSize: 14,
     lineHeight: 20,
+    color: Colors.text,
   },
   bodyXSmall: {
     fontFamily: Inter.Regular,
     fontSize: 12,
     lineHeight: 16,
     letterSpacing: 0.12,
+    color: Colors.text,
   },
   bodyXXSmall: {
     fontFamily: Inter.Regular,
     fontSize: 10,
     lineHeight: 12,
     letterSpacing: 0.2,
+    color: Colors.text,
   },
 })

--- a/src/webview/__snapshots__/WebViewAndroidBottomSheet.test.tsx.snap
+++ b/src/webview/__snapshots__/WebViewAndroidBottomSheet.test.tsx.snap
@@ -200,6 +200,7 @@ exports[`WebViewAndroidBottomSheet renders correctly when visible 1`] = `
         <Text
           style={
             {
+              "color": "#FFFFFF",
               "fontFamily": "Inter-Regular",
               "fontSize": 16,
               "lineHeight": 24,
@@ -245,6 +246,7 @@ exports[`WebViewAndroidBottomSheet renders correctly when visible 1`] = `
         <Text
           style={
             {
+              "color": "#FFFFFF",
               "fontFamily": "Inter-Regular",
               "fontSize": 16,
               "lineHeight": 24,


### PR DESCRIPTION
### Description

- Updated default font color to white
- Updated bottom sheet background to dark blue (doesn't account for all bottom sheets)
- Updated status bar to light (so time / battery / etc show up as white on the dark background)
- Commented statsig warning log which is noisy with statsig disabled

### Test plan

Manual. 

Bottom sheet example:
<img src="https://github.com/user-attachments/assets/5f6e8c9f-7b98-4e56-9945-5acbfe309e67" width="250" />


### Related issues

- Part of ACT-1523


