### PR TITLE
feat(send): update styles to match design

### DIFF
--- a/src/components/InLineNotification.tsx
+++ b/src/components/InLineNotification.tsx
@@ -64,7 +64,7 @@ export function InLineNotification({
     )
   const Icon = variantIcons[variant]
 
-  const backgroundStyle = { backgroundColor: variantColor.secondary }
+  const backgroundStyle = { backgroundColor: `${variantColor.secondary}66` } // secondary color with 40% opacity
   const borderStyle = withBorder && {
     borderWidth: 1,
     borderColor: `${variantColor.primary}80`, // primary color with 50% opacity
@@ -121,7 +121,6 @@ const styles = StyleSheet.create({
   },
   bodyText: {
     ...typeScale.bodyXSmall,
-    color: Colors.white,
   },
   ctaLabel: {
     ...typeScale.labelSmall,
@@ -134,20 +133,20 @@ const styles = StyleSheet.create({
 
 const variantColors: Record<NotificationVariant, CustomColors> = {
   [NotificationVariant.Info]: {
-    primary: Colors.white,
-    secondary: Colors.blue100,
+    primary: Colors.text,
+    secondary: Colors.gray5,
   },
   [NotificationVariant.Success]: {
-    primary: Colors.successDark,
-    secondary: Colors.successLight,
+    primary: Colors.text,
+    secondary: Colors.successDark,
   },
   [NotificationVariant.Warning]: {
-    primary: Colors.warningDark,
-    secondary: Colors.warningLight,
+    primary: Colors.text,
+    secondary: Colors.warningDark,
   },
   [NotificationVariant.Error]: {
-    primary: Colors.errorDark,
-    secondary: Colors.errorLight,
+    primary: Colors.text,
+    secondary: Colors.errorDark,
   },
 }
 

--- a/src/components/SegmentedControl.tsx
+++ b/src/components/SegmentedControl.tsx
@@ -29,8 +29,12 @@ export default function SegmentedControl({ values, selectedIndex = 0, onChange }
     Extrapolation.CLAMP
   )
 
-  const color = interpolateColor(selectedIndex, [0.5, 1], [colors.white, colors.darkBlue])
-  const colorInverted = interpolateColor(selectedIndex, [0.5, 1], [colors.darkBlue, colors.white])
+  const color = interpolateColor(selectedIndex, [0.5, 1], [colors.white, colors.white])
+  const colorInverted = interpolateColor(
+    selectedIndex,
+    [0.5, 1],
+    [colors.darkBlue, colors.darkBlue]
+  )
 
   const onLayout = ({
     nativeEvent: {

--- a/src/navigator/QRNavigator.tsx
+++ b/src/navigator/QRNavigator.tsx
@@ -142,10 +142,10 @@ QRNavigator.navigationOptions = {
 
 const styles = StyleSheet.create({
   container: {
-    backgroundColor: Colors.white,
+    backgroundColor: Colors.background,
   },
   sceneContainerStyle: {
-    backgroundColor: Colors.white,
+    backgroundColor: Colors.background,
   },
   viewContainer: {
     flex: 1,

--- a/src/qrcode/NotAuthorizedView.tsx
+++ b/src/qrcode/NotAuthorizedView.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next'
 import { Platform, StyleSheet, Text, View } from 'react-native'
 import * as AndroidOpenSettings from 'react-native-android-open-settings'
 import TextButton from 'src/components/TextButton'
-import colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { navigateToURI } from 'src/utils/linking'
 
@@ -36,11 +35,9 @@ const styles = StyleSheet.create({
   title: {
     ...typeScale.titleSmall,
     marginBottom: 8,
-    color: colors.darkBlue,
   },
   description: {
     ...typeScale.bodyMedium,
-    color: colors.darkBlue,
     textAlign: 'center',
     marginBottom: 16,
   },

--- a/src/qrcode/QRScanner.tsx
+++ b/src/qrcode/QRScanner.tsx
@@ -152,7 +152,6 @@ const styles = StyleSheet.create({
     bottom: 32,
     ...typeScale.labelSemiBoldSmall,
     lineHeight: undefined,
-    color: colors.darkBlue,
     textAlign: 'center',
     paddingHorizontal: 30,
   },

--- a/src/qrcode/QRTabBar.tsx
+++ b/src/qrcode/QRTabBar.tsx
@@ -41,7 +41,7 @@ export default function QRTabBar({
     [state, descriptors]
   )
 
-  const color = state.index === 0 ? colors.white : colors.darkBlue
+  const color = state.index === 0 ? colors.white : colors.white
   const shareOpacity = interpolate(state.index, [0, 0.1], [1, 0], Extrapolation.CLAMP)
 
   const onPressClose = () => {

--- a/src/qrcode/__snapshots__/NotAuthorizedView.test.tsx.snap
+++ b/src/qrcode/__snapshots__/NotAuthorizedView.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`NotAuthorizedView renders correctly 1`] = `
   <Text
     style={
       {
-        "color": "#242843",
+        "color": "#FFFFFF",
         "fontFamily": "Inter-Bold",
         "fontSize": 20,
         "lineHeight": 28,
@@ -27,7 +27,7 @@ exports[`NotAuthorizedView renders correctly 1`] = `
   <Text
     style={
       {
-        "color": "#242843",
+        "color": "#FFFFFF",
         "fontFamily": "Inter-Regular",
         "fontSize": 16,
         "lineHeight": 24,

--- a/src/recipients/RecipientItemV2.tsx
+++ b/src/recipients/RecipientItemV2.tsx
@@ -107,7 +107,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   rowSelected: {
-    backgroundColor: Colors.blue100,
+    backgroundColor: Colors.blue200,
   },
   avatar: {
     marginRight: Spacing.Small12,

--- a/src/send/EnterAmount.tsx
+++ b/src/send/EnterAmount.tsx
@@ -357,8 +357,9 @@ const styles = StyleSheet.create({
   feeContainer: {
     marginVertical: Spacing.Regular16,
     padding: Spacing.Regular16,
+    backgroundColor: Colors.blue100,
     borderColor: Colors.blue200,
-    borderWidth: 1,
+    borderWidth: 0,
     borderRadius: 12,
     gap: Spacing.Smallest8,
     flexDirection: 'row',

--- a/src/send/EnterAmount.tsx
+++ b/src/send/EnterAmount.tsx
@@ -358,8 +358,6 @@ const styles = StyleSheet.create({
     marginVertical: Spacing.Regular16,
     padding: Spacing.Regular16,
     backgroundColor: Colors.blue100,
-    borderColor: Colors.blue200,
-    borderWidth: 0,
     borderRadius: 12,
     gap: Spacing.Smallest8,
     flexDirection: 'row',

--- a/src/send/SendConfirmation.tsx
+++ b/src/send/SendConfirmation.tsx
@@ -284,7 +284,7 @@ const styles = StyleSheet.create({
   },
   amountSubscript: {
     ...typeScale.bodyMedium,
-    color: colors.gray5,
+    color: colors.lightBlue,
     paddingBottom: 16,
   },
   subHeading: {

--- a/src/send/SendSelectRecipient.tsx
+++ b/src/send/SendSelectRecipient.tsx
@@ -104,7 +104,6 @@ const getStartedStyles = StyleSheet.create({
   },
   title: {
     ...typeScale.labelMedium,
-    color: colors.gray5,
   },
   optionWrapper: {
     flexDirection: 'row',
@@ -123,7 +122,6 @@ const getStartedStyles = StyleSheet.create({
   },
   optionTitle: {
     ...typeScale.labelSmall,
-    color: colors.gray5,
     paddingBottom: Spacing.Tiny4,
   },
   optionSubtitle: {

--- a/src/send/SendSelectRecipientSearchInput.tsx
+++ b/src/send/SendSelectRecipientSearchInput.tsx
@@ -47,9 +47,8 @@ const styles = StyleSheet.create({
     columnGap: Spacing.Smallest8,
     paddingVertical: Spacing.Smallest8,
     paddingHorizontal: Spacing.Small12,
-    borderWidth: 1,
-    borderColor: colors.blue200,
     borderRadius: 100,
+    backgroundColor: colors.blue100,
   },
   input: {
     ...typeScale.bodySmall,

--- a/src/send/__snapshots__/SendConfirmation.test.tsx.snap
+++ b/src/send/__snapshots__/SendConfirmation.test.tsx.snap
@@ -262,7 +262,7 @@ exports[`SendConfirmation renders correctly 1`] = `
             <Text
               style={
                 {
-                  "color": "#505050",
+                  "color": "#B7B9C9",
                   "fontFamily": "Inter-Regular",
                   "fontSize": 16,
                   "lineHeight": 24,


### PR DESCRIPTION
### Description

Update send screens to match [design](https://www.figma.com/design/xJ4CFXy7dL0oijQD3kSqrE/Mobile-Stack---Beefy?node-id=2626-136356&t=I4mqjUI9y91ySnfm-0)

InLineNotifications [design](https://www.figma.com/design/xJ4CFXy7dL0oijQD3kSqrE/Mobile-Stack---Beefy?node-id=2626-136153&t=I4mqjUI9y91ySnfm-0)

### Test plan

Two things out of sync with design:
- EnterAmount component, addressed in #13 
- SendConfirmation icon, this screen is being replaced in valora currently so we can just pull that in (https://github.com/valora-inc/wallet/pull/6402)

https://github.com/user-attachments/assets/ae9d5f1c-ce69-4ecf-81f6-467f10120f99

https://github.com/user-attachments/assets/c75ddd77-1f05-4257-ac5a-21eb4998f2dd

### Related issues

- Part of ACT-1526
