### PR TITLE
feat(swap): update styles to match design

### DIFF
--- a/src/components/TextInput.tsx
+++ b/src/components/TextInput.tsx
@@ -94,7 +94,7 @@ export class CTextInput extends React.Component<Props, State> {
             onPress={this.onClear}
             solid={true}
             size={20}
-            activeColor={Colors.gray5}
+            activeColor={Colors.lightBlue}
             inactiveColor={Colors.blue100}
           />
         )}

--- a/src/styles/colors.tsx
+++ b/src/styles/colors.tsx
@@ -24,6 +24,9 @@ enum Colors {
   gradientBorderLeft = '#26d98a',
   gradientBorderRight = '#ffd52c',
 
+  skeletonPlaceholderBackground = '#FFFFFFA3',
+  skeletonPlaceholderHighlight = '#4EB258A3',
+
   // shadows
   softShadow = 'rgba(45, 49, 84, 0.4)', // called drop shadow in figma
   lightShadow = 'rgba(48, 46, 37, 0.15)',

--- a/src/swap/FeeInfoBottomSheet.tsx
+++ b/src/swap/FeeInfoBottomSheet.tsx
@@ -163,7 +163,7 @@ const styles = StyleSheet.create({
   divider: {
     marginVertical: Spacing.Small12,
     height: 1,
-    backgroundColor: Colors.blue200,
+    backgroundColor: Colors.white,
     width: '100%',
   },
   label: {

--- a/src/swap/SwapAmountInput.tsx
+++ b/src/swap/SwapAmountInput.tsx
@@ -138,8 +138,8 @@ const SwapAmountInput = ({
               <View style={styles.loaderContainer}>
                 <SkeletonPlaceholder
                   borderRadius={100} // ensure rounded corners with font scaling
-                  backgroundColor={Colors.blue200}
-                  highlightColor={Colors.darkBlue}
+                  backgroundColor={Colors.skeletonPlaceholderBackground}
+                  highlightColor={Colors.skeletonPlaceholderHighlight}
                   testID="SwapAmountInput/Loader"
                 >
                   <View style={styles.loader} />
@@ -167,8 +167,6 @@ const SwapAmountInput = ({
 const styles = StyleSheet.create({
   container: {
     backgroundColor: Colors.blue100,
-    borderColor: Colors.blue200,
-    borderWidth: 1,
   },
   tokenInfo: {
     alignItems: 'center',

--- a/src/swap/SwapScreen.tsx
+++ b/src/swap/SwapScreen.tsx
@@ -799,8 +799,8 @@ export function SwapScreen({ route }: Props) {
               onPress={handleSwitchTokens}
               testID="SwapScreen/SwitchTokens"
             >
-              <CircledIcon radius={Spacing.Large32} backgroundColor={colors.white}>
-                <ArrowDown color={colors.darkBlue} />
+              <CircledIcon radius={Spacing.Large32} backgroundColor={colors.background}>
+                <ArrowDown color={colors.white} />
               </CircledIcon>
             </Touchable>
           </View>

--- a/src/swap/SwapTransactionDetails.tsx
+++ b/src/swap/SwapTransactionDetails.tsx
@@ -122,8 +122,8 @@ function ValueWithLoading({ value, isLoading }: { value: React.ReactNode; isLoad
           <View style={styles.loaderContainer}>
             <SkeletonPlaceholder
               borderRadius={100}
-              backgroundColor={colors.blue200}
-              highlightColor={colors.darkBlue}
+              backgroundColor={colors.skeletonPlaceholderBackground}
+              highlightColor={colors.skeletonPlaceholderHighlight}
               testID="SwapTransactionDetails/ExchangeRate/Loader"
             >
               <View style={styles.loader} />


### PR DESCRIPTION
### Description

[Figma](https://www.figma.com/design/xJ4CFXy7dL0oijQD3kSqrE/Mobile-Stack---Beefy?node-id=2626-136354&t=SiNg37h4Nfbukyze-0)

### Test plan

Tested by manually enabling the swap firebase config (currently off by default).



https://github.com/user-attachments/assets/870517b7-3df0-4ada-894b-3b0b48eefa9e

For some reason, the animations were super slow, I didn't investigate it here since this is being replaced by a new V2 swap screen.

### Related issues

- Part of ACT-1526

